### PR TITLE
fix: rename field to prevent IE runtime error

### DIFF
--- a/src/auro-input.js
+++ b/src/auro-input.js
@@ -126,7 +126,7 @@ export default class AuroInput extends BaseInput {
         ?required="${this.required}"
         ?disabled="${this.disabled}"
         .value="${ifDefined(this.value)}"
-        aria-describedby="${this.uniqueID}"
+        aria-describedby="${this.uniqueId}"
       />
 
       ${this.required
@@ -143,7 +143,7 @@ export default class AuroInput extends BaseInput {
             </div>
           </div>`
         : html`
-          <p id="${this.uniqueID}" class="inputElement-helpText ${this.getDisabledClass()}">${this.helpText}</p>
+          <p id="${this.uniqueId}" class="inputElement-helpText ${this.getDisabledClass()}">${this.helpText}</p>
           <div class="iconContainer">
             <div class="inputElement-icon">
               ${this.showPasswordIcon()}

--- a/src/base-input.js
+++ b/src/base-input.js
@@ -71,7 +71,7 @@ export default class BaseInput extends LitElement {
     /**
      * @private Value is unique ID set at runtime
      */
-    this.uniqueID = Math.random().toString(36).substring(2, 8);
+    this.uniqueId = Math.random().toString(36).substring(2, 8);
   }
 
   // function to define props used within the scope of this component


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Summary:

uniqueID is a readonly property on elements in IE. Assigning to `this.uniqueID` was causing a runtime error in some frameworks. To fix this, I renamed the field to `uniqueId`. 

[For reference](https://docs.microsoft.com/en-us/openspecs/ie_standards/ms-html401e/064003f1-1980-4afd-b323-f4470dc4fc29)

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
