### PR TITLE
Restrict use of cursor jump function

### DIFF
--- a/src/base-input.js
+++ b/src/base-input.js
@@ -166,9 +166,11 @@ export default class BaseInput extends LitElement {
     }
 
     // prevents cursor jumping in Safari
-    this.updateComplete.then(() => {
-      this.inputElement.setSelectionRange(selectionStart, selectionStart)
-    });
+    if (this.type !== "credit-card") {
+      this.updateComplete.then(() => {
+        this.inputElement.setSelectionRange(selectionStart, selectionStart)
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
# Alaska Airlines Pull Request

Here is what I discovered. Even when I commented out [the lines](https://github.com/AlaskaAirlines/auro-input/blob/main/src/base-input.js#L169-L171) that address the Safari issue, the credit-card still suffers from a scenario where the user can move the cursor and the 1st character is correct, but the next is at the end of the line. I am assuming that this has something to do with the value reassignment. 

This led me to think that this is what is creating the more severe issue with Firefox. 

**Fixes:** #27 

## Summary:

The solution proposed is to not allow the application of the cursor correction to the `tyle="credit-card". This does not address the issue above, but this does make the credit card type useable in all browsers. 

While the issue described above is not ideal, the experience is 100% consistent across all browsers. 

**SCREEN GRABS NEEDED**

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Tested:

- [x] Safari (desktop / iOS)
- [x] Chrome
- [x] Edge
- [x] Firefox

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
