### PR TITLE
fix: show password toggle when property set (#30)

### DIFF
--- a/src/auro-input.js
+++ b/src/auro-input.js
@@ -44,7 +44,8 @@ export default class AuroInput extends BaseInput {
   // function to define props used within the scope of this component
   static get properties() {
     return {
-      ...super.properties
+      ...super.properties,
+      showPassword: {state: true}
     };
   }
 
@@ -69,15 +70,8 @@ export default class AuroInput extends BaseInput {
    * @returns {string} returns string based on type
    */
   handleClickShowPassword() {
-    if (this.type === "password") {
-      this.type = "text";
-      this.showPassword = true;
-      this.focus();
-    } else if (this.type === "text") {
-      this.type = "password";
-      this.showPassword = false;
-      this.focus();
-    }
+    this.showPassword = !this.showPassword;
+    this.focus();
   }
 
   /**
@@ -113,10 +107,9 @@ export default class AuroInput extends BaseInput {
    * @returns {string} html string
    */
   showPasswordIcon() {
-    if (this.type === 'password' || this.type === 'text') {
+    if (this.type === 'password') {
       return html`
       <button
-        id="passwordToggle"
         class="iconButton passwordToggle"
         @click="${this.handleClickShowPassword}"
         tabindex="-1"
@@ -283,7 +276,7 @@ export default class AuroInput extends BaseInput {
         class="${classMap(inputClasses)}"
         id="${this.id}"
         name="${ifDefined(this.name)}"
-        type="${this.getInputType(this.type)}"
+        type="${this.type === 'password' && this.showPassword ? 'text' : this.getInputType(this.type)}"
         pattern="${ifDefined(this.type === 'credit-card' && !this.noValidate && this.maxLength ? `.{${this.maxLength},${this.maxLength}}` : undefined)}"
         maxlength="${ifDefined(this.maxLength ? this.maxLength : undefined)}"
         inputmode="${ifDefined(this.numericKeyboard ? `numeric` : undefined)}"

--- a/src/style.scss
+++ b/src/style.scss
@@ -25,13 +25,11 @@ auro-input-light {
   visibility: hidden;
 }
 
-:host([type=password]) {
-  .passwordIcon--show {
-    .passwordToggle {
-      visibility: visible;
+.passwordIcon--show {
+  .passwordToggle {
+    visibility: visible;
 
-      cursor: pointer;
-    }
+    cursor: pointer;
   }
 }
 

--- a/test/auro-input.test.js
+++ b/test/auro-input.test.js
@@ -39,7 +39,7 @@ describe('auro-input', () => {
       <auro-input type="password" value="password" label="password"></auro-input>
     `);
 
-    const toggle = el.shadowRoot.querySelector('#passwordToggle');
+    const toggle = el.shadowRoot.querySelector('.passwordToggle');
     const input = el.shadowRoot.querySelector('.inputElement');
     toggle.click();
     await elementUpdated(input);


### PR DESCRIPTION
# Alaska Airlines Pull Request

This PR makes it so the hide/show password toggle is shown when the `type` property or attribute is set to `"password"`. Previously, this only worked when the `type` attribute was set. This is necessary for frameworks like Svelte, which prefer to set the property when available.

Fixes #30

## Summary:

In order to hide/show the password, we were toggling the element's type property between "password" and "text". Instead, I only set an internal state property `_showPassword` and used that to determine the inner `<input>`'s type attribute. The auro-input's type property remains equal to "password". 

Originally I thought we would need to reflect the property since we were using the attribute for styling, but that didn't end up being necessary. I was able to remove the `:host([type="password'])` selector and rely on the toggle only being added to the DOM when `this.type === 'password'`. 

I verified that this change works in a local Svelte app. The password icon displays and can be toggled as many times as desired.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
