### PR TITLE
Jbaker/prop defaults/#35

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -5,15 +5,15 @@
 | Property                  | Attribute                 | Type      | Default | Description                                      |
 |---------------------------|---------------------------|-----------|---------|--------------------------------------------------|
 | `customValidationMessage` | `customValidationMessage` | `String`  |         | Overrides the browser validation message when the input is invalid. |
-| `disabled`                | `disabled`                | `Boolean` |         | If set, disables the input.                      |
+| `disabled`                | `disabled`                | `Boolean` | false   | If set, disables the input.                      |
 | `helpText`                | `helpText`                | `String`  |         | Sets the help text displayed below the input.    |
-| `icon`                    | `icon`                    | `Boolean` |         | If set, will render an icon inside the input to the left of the value. Support is limited to auro-input instances with credit card format. |
+| `icon`                    | `icon`                    | `Boolean` | false   | If set, will render an icon inside the input to the left of the value. Support is limited to auro-input instances with credit card format. |
 | `id`                      | `id`                      | `String`  |         | Sets the unique ID of the element.               |
-| `isValid`                 | `isValid`                 | `Boolean` |         | Can be accessed to determine if the input is in an error state or not. Not intended to be set by the consumer. |
+| `isValid`                 | `isValid`                 | `Boolean` | true    | Can be accessed to determine if the input is in an error state or not. Not intended to be set by the consumer. |
 | `label`                   | `label`                   | `String`  |         | Sets the label text for the input.               |
 | `name`                    | `name`                    | `String`  |         | Populates the `name` attribute on the input.     |
-| `noValidate`              | `noValidate`              | `Boolean` |         | If set, disables auto-validation on blur.        |
-| `required`                | `required`                | `Boolean` |         | Populates the `required` attribute on the input. Used for client-side validation. |
+| `noValidate`              | `noValidate`              | `Boolean` | false   | If set, disables auto-validation on blur.        |
+| `required`                | `required`                | `Boolean` | false   | Populates the `required` attribute on the input. Used for client-side validation. |
 | `type`                    | `type`                    | `String`  | "text"  | Populates the `type` attribute on the input. Allowed values are `password`, `email`, `credit-card`  or `text`. If given value is not allowed or set, defaults to `text`. |
 | `value`                   | `value`                   | `String`  |         | Populates the `value` attribute on the input. Can also be read to retrieve the current value of the input. |
 

--- a/src/base-input.js
+++ b/src/base-input.js
@@ -86,6 +86,12 @@ export default class BaseInput extends LitElement {
      * @private Value is unique ID set at runtime
      */
     this.uniqueId = Math.random().toString(36).substring(2, 8);
+
+    this.icon = false;
+    this.disabled = false;
+    this.isValid = true;
+    this.required = false;
+    this.noValidate = false;
   }
 
   // function to define props used within the scope of this component


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Fixes:** #35
## Summary:

This change adds declared defaults for the boolean properties that are used as attributes in the template. This allows the primitives to work correctly in Svelte where these are set on the elements as properties rather than attributes.

https://css-tricks.com/using-custom-elements-in-svelte/#boolean-attributes

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
