### PR TITLE
Respect "novalidate" attribute after error set

### DIFF
--- a/src/base-input.js
+++ b/src/base-input.js
@@ -363,9 +363,7 @@ export default class BaseInput extends LitElement {
     this.hasBlurred = true;
     this.inputElement.scrollLeft = 100;
 
-    if (!this.noValidate) {
-      this.validate();
-    }
+    this.validate();
   }
 
   /**
@@ -374,14 +372,13 @@ export default class BaseInput extends LitElement {
    * @return {void}
    */
   validate() {
-
     if (this.error && this.error.length > 0) {
       this.isValid = false;
 
       return;
     }
 
-    this.isValid = this.inputElement.checkValidity();
+    this.isValid = this.noValidate ? true : this.inputElement.checkValidity();
     this.internalError = this.isValid ? null : this.inputElement.validationMessage;
   }
 
@@ -562,9 +559,7 @@ export default class BaseInput extends LitElement {
 
     this.maxLength = card.formatLength;
 
-    if (!this.noValidate) {
-      this.customValidationMessage = card.customValidationMessage;
-    }
+    this.customValidationMessage = card.customValidationMessage;
 
     if (this.icon) {
       this.inputIconName = card.cardIcon;

--- a/test/auro-input.test.js
+++ b/test/auro-input.test.js
@@ -151,7 +151,7 @@ describe('auro-input', () => {
     expect(el.isValid).to.be.true;
   });
 
-  it('auro-input is accessible', async () => {
+  it('is accessible', async () => {
     const el = await fixture(html`
       <auro-input cssclass="testClass"></auro-input>
     `);
@@ -159,108 +159,112 @@ describe('auro-input', () => {
     await expect(el).to.be.accessible();
   });
 
-  it('auro-input custom element is defined', async () => {
+  it('defines the custom element', async () => {
     const el = await !!customElements.get("auro-input");
 
     await expect(el).to.be.true;
   });
 
-  it('handles date formatting - MM/DD/YYYY', async () => {
-    const el = await fixture(html`
-      <auro-input id="format-date" type="month-day-year" required></auro-input>
-    `);
-
-    expect(el.shadowRoot.querySelector('#format-date')).to.have.attribute('placeholder', 'MM/DD/YYYY');
+  describe('handles date formatting', () => {
+    it('MM/DD/YYYY', async () => {
+      const el = await fixture(html`
+        <auro-input id="format-date" type="month-day-year" required></auro-input>
+      `);
+  
+      expect(el.shadowRoot.querySelector('#format-date')).to.have.attribute('placeholder', 'MM/DD/YYYY');
+    });
+  
+    it('YYYY/MM/DD', async () => {
+      const el = await fixture(html`
+        <auro-input id="format-date" type="year-month-day" required></auro-input>
+      `);
+  
+      expect(el.shadowRoot.querySelector('#format-date')).to.have.attribute('placeholder', 'YYYY/MM/DD');
+    });
+  
+    it('MM/YY', async () => {
+      const el = await fixture(html`
+        <auro-input id="format-date" type="month-year" required></auro-input>
+      `);
+  
+      expect(el.shadowRoot.querySelector('#format-date')).to.have.attribute('placeholder', 'MM/YY');
+    });
   });
-
-  it('handles date formatting - YYYY/MM/DD', async () => {
-    const el = await fixture(html`
-      <auro-input id="format-date" type="year-month-day" required></auro-input>
-    `);
-
-    expect(el.shadowRoot.querySelector('#format-date')).to.have.attribute('placeholder', 'YYYY/MM/DD');
-  });
-
-  it('handles date formatting - MM/YY', async () => {
-    const el = await fixture(html`
-      <auro-input id="format-date" type="month-year" required></auro-input>
-    `);
-
-    expect(el.shadowRoot.querySelector('#format-date')).to.have.attribute('placeholder', 'MM/YY');
-  });
-
-  it('handles credit card formatting - starts with "34" is American Express', async () => {
-    const el = await fixture(html`
-      <auro-input id="format-ccWithIcon" type="credit-card" icon="true" label="Credit Card Number with Icon" required></auro-input>
-    `);
-
-
-    await setInputValue(el, '34');
-    expect(el.shadowRoot.querySelector('.accentIcon')).to.have.attribute('name', 'cc-amex');
-  });
-
-  it('handles credit card formatting - starts with "37" is American Express', async () => {
-    const el = await fixture(html`
-      <auro-input id="format-ccWithIcon" type="credit-card" icon="true" label="Credit Card Number with Icon" required></auro-input>
-    `);
-
-    await setInputValue(el, '37');
-    expect(el.shadowRoot.querySelector('.accentIcon')).to.have.attribute('name', 'cc-amex');
-  });
-
-  it('handles credit card formatting - starts with "4" is Visa', async () => {
-    const el = await fixture(html`
-      <auro-input id="format-ccWithIcon" type="credit-card" icon="true" label="Credit Card Number with Icon" required></auro-input>
-    `);
-
-    await setInputValue(el, '4');
-    expect(el.shadowRoot.querySelector('.accentIcon')).to.have.attribute('name', 'cc-visa');
-  });
-
-  it('handles credit card formatting - starts with "22" is MasterCard', async () => {
-    const el = await fixture(html`
-      <auro-input id="format-ccWithIcon" type="credit-card" icon="true" label="Credit Card Number with Icon" required></auro-input>
-    `);
-
-    await setInputValue(el, '5');
-    expect(el.shadowRoot.querySelector('.accentIcon')).to.have.attribute('name', 'cc-mastercard');
-  });
-
-  it('handles credit card formatting - starts with "644" is Discover Card', async () => {
-    const el = await fixture(html`
-      <auro-input id="format-ccWithIcon" type="credit-card" icon="true" label="Credit Card Number with Icon" required></auro-input>
-    `);
-
-    await setInputValue(el, '6');
-    expect(el.shadowRoot.querySelector('.accentIcon')).to.have.attribute('name', 'cc-discover');
-  });
-
-  it('handles credit card formatting - Undefined Value', async () => {
-    const el = await fixture(html`
-      <auro-input id="format-ccWithIcon" type="credit-card" icon="true" label="Credit Card Number with Icon" required></auro-input>
-    `);
-
-    await setInputValue(el, undefined);
-    expect(el.shadowRoot.querySelector('.accentIcon')).to.have.attribute('name', 'credit-card');
-  });
-
-  it('handles credit card formatting - Empty Value', async () => {
-    const el = await fixture(html`
-      <auro-input id="format-ccWithIcon" type="credit-card" icon="true" label="Credit Card Number with Icon" required></auro-input>
-    `);
-
-    await setInputValue(el, '');
-    expect(el.shadowRoot.querySelector('.accentIcon')).to.have.attribute('name', 'credit-card');
-  });
-
-  it('handles credit card formatting - Alaska Air Visa Cards', async () => {
-    const el = await fixture(html`
-      <auro-input id="format-ccWithIcon" type="credit-card" icon="true" label="Credit Card Number with Icon" required></auro-input>
-    `);
-
-    await setInputValue(el, '4147 34');
-    expect(el.shadowRoot.querySelector('.accentIcon')).to.have.attribute('name', 'cc-visa');
-  });
+  
+  describe('handles credit card formatting', () => {
+    it('starts with "34" is American Express', async () => {
+      const el = await fixture(html`
+        <auro-input id="format-ccWithIcon" type="credit-card" icon label="Credit Card Number with Icon" required></auro-input>
+      `);
+  
+  
+      await setInputValue(el, '34');
+      expect(el.shadowRoot.querySelector('.accentIcon')).to.have.attribute('name', 'cc-amex');
+    });
+  
+    it('starts with "37" is American Express', async () => {
+      const el = await fixture(html`
+        <auro-input id="format-ccWithIcon" type="credit-card" icon label="Credit Card Number with Icon" required></auro-input>
+      `);
+  
+      await setInputValue(el, '37');
+      expect(el.shadowRoot.querySelector('.accentIcon')).to.have.attribute('name', 'cc-amex');
+    });
+  
+    it('starts with "4" is Visa', async () => {
+      const el = await fixture(html`
+        <auro-input id="format-ccWithIcon" type="credit-card" icon label="Credit Card Number with Icon" required></auro-input>
+      `);
+  
+      await setInputValue(el, '4');
+      expect(el.shadowRoot.querySelector('.accentIcon')).to.have.attribute('name', 'cc-visa');
+    });
+  
+    it('starts with "22" is MasterCard', async () => {
+      const el = await fixture(html`
+        <auro-input id="format-ccWithIcon" type="credit-card" icon label="Credit Card Number with Icon" required></auro-input>
+      `);
+  
+      await setInputValue(el, '5');
+      expect(el.shadowRoot.querySelector('.accentIcon')).to.have.attribute('name', 'cc-mastercard');
+    });
+  
+    it('starts with "644" is Discover Card', async () => {
+      const el = await fixture(html`
+        <auro-input id="format-ccWithIcon" type="credit-card" icon label="Credit Card Number with Icon" required></auro-input>
+      `);
+  
+      await setInputValue(el, '6');
+      expect(el.shadowRoot.querySelector('.accentIcon')).to.have.attribute('name', 'cc-discover');
+    });
+  
+    it('Undefined Value', async () => {
+      const el = await fixture(html`
+        <auro-input id="format-ccWithIcon" type="credit-card" icon label="Credit Card Number with Icon" required></auro-input>
+      `);
+  
+      await setInputValue(el, undefined);
+      expect(el.shadowRoot.querySelector('.accentIcon')).to.have.attribute('name', 'credit-card');
+    });
+  
+    it('Empty Value', async () => {
+      const el = await fixture(html`
+        <auro-input id="format-ccWithIcon" type="credit-card" icon label="Credit Card Number with Icon" required></auro-input>
+      `);
+  
+      await setInputValue(el, '');
+      expect(el.shadowRoot.querySelector('.accentIcon')).to.have.attribute('name', 'credit-card');
+    });
+  
+    it('Alaska Air Visa Cards', async () => {
+      const el = await fixture(html`
+        <auro-input id="format-ccWithIcon" type="credit-card" icon label="Credit Card Number with Icon" required></auro-input>
+      `);
+  
+      await setInputValue(el, '4147 34');
+      expect(el.shadowRoot.querySelector('.accentIcon')).to.have.attribute('name', 'cc-visa');
+    });
+  })
 });
 
 function setInputValue(el, value) {

--- a/test/auro-input.test.js
+++ b/test/auro-input.test.js
@@ -106,6 +106,20 @@ describe('auro-input', () => {
     expect(el.isValid).to.be.false;
   });
 
+  it('does not validate when novalidate is true', async () => {
+    const el = await fixture(html`
+      <auro-input required type="email" label="Label" novalidate></auro-input>
+    `);
+    const input = el.shadowRoot.querySelector('input');
+
+    input.focus();
+    setInputValue(el, '');
+    input.blur();
+    await elementUpdated(el);
+
+    expect(el.isValid).to.be.true;
+  });
+
   it('sets aria-invalid', async () => {
     const el = await fixture(html`
       <auro-input required></auro-input>
@@ -147,6 +161,18 @@ describe('auro-input', () => {
     `);
 
     el.error = '';
+    await elementUpdated(el);
+    expect(el.isValid).to.be.true;
+  });
+
+  it('updates validity when error message removed after creation and novalidate is true', async () => {
+    const el = await fixture(html`
+      <auro-input error="Test error" novalidate required></auro-input>
+    `);
+
+    expect(el.isValid).to.be.false;
+    el.error = '';
+
     await elementUpdated(el);
     expect(el.isValid).to.be.true;
   });


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #107

## Summary:

With this change, when `noValidate` is set:
1. If the `error` attribute is set, then the error message is shown and the invalid state applies
2. If the `error` attribute is not set, then the input is valid, regardless of the input type or if it is required

Before this change, setting the "error" attribute on the element would mean that input validation would continue to run on the element, even when the error attribute was removed. This PR fixes that behavior by only running the browser input validation when `noValidate` is false. I moved all the `noValidate` checks into the `validate` method, since we were checking the same thing in a few different places. 

This also adds a test around the novalidate behavior that was previously missing.

The diff is a little confusing for the test changes -- please review the individual commits separately. The first commit simply moves CC and Date tests into separate blocks to organize them better.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
