### PR TITLE
fix: remove components dir from sweep command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-input",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-input",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "postinstall": "node packageScripts/postinstall.mjs",
     "sass:render": "sass-render 'src/**/*.css' 'components/**/*.css' -t ./node_modules/@aurodesignsystem/auro-library/scripts/build/staticStyles-template.js",
     "serve": "web-dev-server --open demo/ --node-resolve --watch",
-    "sweep": "rm -rf ./demo/css ./dist | find ./demo ./dist ./src ./-type f \\( -name \"*.css\" -o -name \"*-css.js\" \\) -delete",
+    "sweep": "rm -rf ./demo/css ./dist | find ./demo ./dist ./src -type f \\( -name \"*.css\" -o -name \"*-css.js\" \\) -delete",
     "test": "wtr --coverage",
     "test:watch": "wtr --watch",
     "prepare": "husky install",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "postinstall": "node packageScripts/postinstall.mjs",
     "sass:render": "sass-render 'src/**/*.css' 'components/**/*.css' -t ./node_modules/@aurodesignsystem/auro-library/scripts/build/staticStyles-template.js",
     "serve": "web-dev-server --open demo/ --node-resolve --watch",
-    "sweep": "find ./demo ./dist ./src ./components -type f \\( -name \"*.css\" -o -name \"*-css.js\" \\) -delete",
+    "sweep": "rm -rf ./demo/css ./dist | find ./demo ./dist ./src ./-type f \\( -name \"*.css\" -o -name \"*-css.js\" \\) -delete",
     "test": "wtr --coverage",
     "test:watch": "wtr --watch",
     "prepare": "husky install",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "postinstall": "node packageScripts/postinstall.mjs",
     "sass:render": "sass-render 'src/**/*.css' 'components/**/*.css' -t ./node_modules/@aurodesignsystem/auro-library/scripts/build/staticStyles-template.js",
     "serve": "web-dev-server --open demo/ --node-resolve --watch",
-    "sweep": "rm -rf ./demo/css ./dist | find ./demo ./dist ./src -type f \\( -name \"*.css\" -o -name \"*-css.js\" \\) -delete",
+    "sweep": "rm -rf ./dist | find ./demo ./dist ./src -type f \\( -name \"*.css\" -o -name \"*-css.js\" \\) -delete",
     "test": "wtr --coverage",
     "test:watch": "wtr --watch",
     "prepare": "husky install",


### PR DESCRIPTION
# Alaska Airlines Pull Request

The `sweep` command was updated in [341](https://github.com/AlaskaAirlines/auro-input/pull/341) to search for the `/components/` folder, which is currently exclusive to the new [auro-form](https://github.com/AlaskaAirlines/auro-form/) component under development as of https://github.com/AlaskaAirlines/auro-form/issues/1.

**Resolves:** 356

## Summary:

- Removed the `/components/` folder from the `sweep` command
- Returned the `rm` command to remove the `dist` and `demo/css` folders

## Type of change:

Please delete options that are not relevant.

- [X] Revision of an existing capability

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Remove the 'components' directory from the 'sweep' command in the package.json to prevent unintended file deletions.

## Summary by Sourcery

Bug Fixes:
- Remove the 'components' directory from the 'sweep' command in the package.json to prevent unintended file deletions.