### PR TITLE
AURO MIGRATION: Update node to v22

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -70,7 +70,7 @@ branches:
         # Required. Require branches to be up to date before merging.
         strict: true
         # Required. The list of status checks to require in order to merge into this branch
-        contexts: ["test (18.x)", "test (20.x)", "license/cla"]
+        contexts: ["test (20.x)", "test (22.x)", "license/cla"]
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: false
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.

--- a/.github/workflows/testPublish.yml
+++ b/.github/workflows/testPublish.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - run: npm ci
       - run: npm run build:release
       - uses: cycjimmy/semantic-release-action@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-input",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-input",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -68,7 +68,7 @@
         "yaml-lint": "^1.7.0"
       },
       "engines": {
-        "node": "^18 || ^20"
+        "node": "^20.x || ^22.x "
       },
       "peerDependencies": {
         "@alaskaairux/icons": "^4.43.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "main": "index.js",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^18 || ^20"
+    "node": "^20.x || ^22.x "
   },
   "dependencies": {
     "@aurodesignsystem/auro-button": "^8.1.3",


### PR DESCRIPTION
Resolves AlaskaAirlines/auro-templates#6

## Summary by Sourcery

Update Node to v22 and revise contributing guidelines.

Build:
- Update Node to v22.

CI:
- Update CI to test against Node v20 and v22.

Documentation:
- Revise contributing guidelines, including updating issue and pull request templates, adding a rebase policy, clarifying commit message guidelines, and updating the code of conduct.

Tests:
- Update CI tests to Node v20 and v22.